### PR TITLE
Default to port 5060 when responding over UDP where the port is unspecified

### DIFF
--- a/nksip/src/nksip_transport.erl
+++ b/nksip/src/nksip_transport.erl
@@ -165,6 +165,10 @@ send(AppId, [#uri{}=Uri|Rest]=All, MakeMsg) ->
     ?debug(AppId, "send to ~p", [All]),
     send(AppId, resolve(Uri)++Rest, MakeMsg);
 
+send(AppId, [{udp, Ip, 0}|Rest], MakeMsg) ->
+    %% If no port was explicitly specified, use default.
+    send(AppId, [{udp, Ip, 5060}|Rest], MakeMsg);
+
 send(AppId, [{udp, Ip, Port}|Rest]=All, MakeMsg) -> 
     ?debug(AppId, "send to ~p", [All]),
     case get_listening(AppId, udp) of


### PR DESCRIPTION
This occurs when the Via header is not receiver tagged, and thus
follows Section 5 of RFC 3263 where the default port for the protocol
should be utilise if not specified in the sent-by.

This remains unnoticed by the tests due to the NkSIP UAC always
including the port in the 'Via' sent-by field.

I've tried to keep this change somewhat low-impact with the new
engine drop in mind.  This could probably do with revisiting to normalise
this decision path for selecting a transport.
