### PR TITLE
Upgrade lager and ranch to the latest stable releases

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -14,6 +14,6 @@
 {cover_export_enabled, true}.
 
 {deps, [
-    {lager, "1.0.0", {git, "git://github.com/basho/lager", {tag, "1.0.0"}}},
+    {lager, "2.*", {git, "git://github.com/basho/lager", {tag, "2.0.0"}}},
     {ranch, ".*", {git, "git://github.com/extend/ranch.git", {tag, "0.8.4"}}}
 ]}.


### PR DESCRIPTION
Our team has been testing against these dependencies for the past few weeks, and there don't seem to be any problems as a result.

Lager, in particular, has some useful features only available in 2.0 (i.e. record pretty printing and tracing) which could be taken in later changes.
