### PR TITLE
RFC 2976 INFO method. 

### DIFF
--- a/nksip/include/nksip.hrl
+++ b/nksip/include/nksip.hrl
@@ -30,8 +30,8 @@
 -define(VERSION, "0.1.0").
 -define(SUPPORTED, <<>>).
 -define(ACCEPT, <<"application/sdp">>).
--define(ALLOW, <<"INVITE, ACK, CANCEL, BYE, OPTIONS">>).
--define(ALLOW_DIALOG, <<"INVITE, ACK, CANCEL, BYE, OPTIONS">>).
+-define(ALLOW, <<"INVITE, ACK, CANCEL, BYE, OPTIONS, INFO">>).
+-define(ALLOW_DIALOG, <<"INVITE, ACK, CANCEL, BYE, OPTIONS, INFO">>).
 
 -define(MSG_QUEUES, 8).
 

--- a/nksip/src/nksip_sipapp.erl
+++ b/nksip/src/nksip_sipapp.erl
@@ -123,7 +123,7 @@
 -author('Carlos Gonzalez <carlosj.gf@gmail.com>').
 
 -export([init/1, get_user_pass/4, authorize/4, route/6, invite/4, reinvite/4, cancel/3, 
-         ack/4, bye/4, options/3, register/3]).
+         ack/4, bye/4, info/4, options/3, register/3]).
 -export([ping_update/3, register_update/3, dialog_update/3, session_update/3]).
 -export([handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
 -include("nksip.hrl").
@@ -447,6 +447,19 @@ ack(_DialogId, _ReqId, _From, State) ->
 
 bye(_DialogId, _ReqId, _From, State) ->
     {reply, ok, State}.
+
+%% @doc Called when a valid INFO request is received.
+%% When an INFO request is received, NkSIP will automatically response 481
+%% <i>Call/Transaction does not exist</i> if it doesn't belong to a current dialog.
+%% If it does, NkSIP this callback functions is called.
+%% If implement this function, you should reply `ok' to send a 200 response back.
+%%
+-spec info(DialogId::nksip_dialog:id(), ReqId::nksip_request:id(),
+    From::from(), State::term()) ->
+  call_reply(nksip:sipreply()).
+
+info(_DialogId, _ReqId, _From, State) ->
+  {reply, ok, State}.
 
 
 %% @doc Called when a OPTIONS request is received.

--- a/nksip/src/nksip_uac.erl
+++ b/nksip/src/nksip_uac.erl
@@ -54,7 +54,7 @@
 -include("nksip.hrl").
 
 -export([options/3, options/2, register/3, invite/3, ack/2, reinvite/2, 
-            bye/2, cancel/2, refresh/2, stun/3]).
+            bye/2, cancel/2, refresh/2, stun/3, info/2]).
 -export([send_request/4, send_request/2]).
 
 
@@ -564,6 +564,20 @@ stun(AppId, UriSpec, _Opts) ->
             end
     end.
 
+%% @doc Sends an <i>INFO</i> for a current dialog.
+%%
+%% Sends an INFO request. Doesn't change the state of the current session.
+
+%% You need to know the `DialogId' of the dialog. You can get from the return of
+%% the initial {@link invite/3}, or using {@link nksip_sipapp:dialog_update/3}
+%% callback function.
+%%
+-spec info(nksip_dialog:spec(), nksip_lib:proplist()) ->
+  {ok, nksip:response_code()} | {reply, nksip:response()} |
+  async | {error, nodialog_errors()}.
+
+info(DialogSpec, Opts) ->
+  send_dialog(DialogSpec, 'INFO', Opts).
 
 %% ===================================================================
 %% Internal

--- a/nksip/src/nksip_uas_fsm.erl
+++ b/nksip/src/nksip_uas_fsm.erl
@@ -333,6 +333,9 @@ process(launch, #state{req=#sipmsg{method=Method, to_tag=ToTag}=Req}=SD)
                 'BYE' ->
                     corecall(bye, [DialogId], SD),
                     start_timer(process, SD);
+                'INFO' ->
+                    corecall(info, [DialogId], SD),
+                    start_timer(process, SD);
                 'OPTIONS' ->
                     corecall(options, [], SD),
                     start_timer(process, SD);
@@ -382,6 +385,8 @@ process(launch, #state{req=Req}=SD) ->
             ?notice(AppId, CallId, "received out-of-dialog ACK", []),
             {stop, normal, SD};
         'BYE' ->
+            stop(no_transaction, SD);
+        'INFO'
             stop(no_transaction, SD);
         'OPTIONS' ->
             corecall(options, [], SD),


### PR DESCRIPTION
Dialog state is not modified, added sending API to nksip_uac.erl and a corresponding callback to nksip_sipapp.erl. Other than keeping the dialog's state, the handling is identical to BYE method. This can be usefull to somebody using nksip to implement a signalling gateway. I'm relatively new to both SIP and OTP so any comments will be greatly appreciated!
