### PR TITLE
Add callback for SipApps to indicate support for SIP extensions

### DIFF
--- a/nksip/include/nksip.hrl
+++ b/nksip/include/nksip.hrl
@@ -28,7 +28,7 @@
 %% ===================================================================
 
 -define(VERSION, "0.1.0").
--define(SUPPORTED, <<>>).
+-define(SUPPORTED, []).
 -define(ACCEPT, <<"application/sdp">>).
 -define(ALLOW, <<"INVITE, ACK, CANCEL, BYE, OPTIONS">>).
 

--- a/nksip/src/nksip_call_proxy.erl
+++ b/nksip/src/nksip_call_proxy.erl
@@ -75,8 +75,8 @@ try_route(UAS, [[First|_]|_]=UriSet, ProxyOpts, Call) ->
                 [] when Stateless ->
                     route_stateless(UAS, First, ProxyOpts, Call);
                 PR ->
-                    Text = nksip_lib:bjoin([T || {T, _} <- PR]),
-                    {reply, {bad_extension, Text}}
+                    Required = [T || {T, _} <- PR],
+                    {reply, {bad_extension, Required}}
             end;
         {reply, Reply} ->
             {reply, Reply}

--- a/nksip/src/nksip_reply.erl
+++ b/nksip/src/nksip_reply.erl
@@ -176,7 +176,7 @@
     {unsupported_media_type, Types::binary()} | 
     {unsupported_media_encoding, Types::binary()} |
     unsupported_uri_scheme | 
-    {bad_extension, Exts::binary()} |
+    {bad_extension, [Exts::binary()]} |
     {interval_too_brief, Min::binary()} |
     temporarily_unavailable |
     no_transaction |
@@ -347,7 +347,7 @@ reqreply({unsupported_media_encoding, Types}) ->
 reqreply(unsupported_uri_scheme) -> 
     #reqreply{code=416};
 reqreply({bad_extension, Exts}) -> 
-    Exts1 = nksip_lib:to_binary(Exts),  
+    Exts1 = nksip_lib:bjoin(Exts),
     #reqreply{
         code = 420, 
         headers = nksip_headers:new([{single, <<"Unsupported">>, Exts1}])

--- a/nksip/src/nksip_sipapp.erl
+++ b/nksip/src/nksip_sipapp.erl
@@ -133,7 +133,7 @@
 -author('Carlos Gonzalez <carlosj.gf@gmail.com>').
 
 -export([init/1, get_user_pass/3, authorize/4, route/6, invite/3, reinvite/3, cancel/2, 
-         ack/3, bye/3, options/3, register/3]).
+         ack/3, bye/3, options/3, register/3, supported/1]).
 -export([ping_update/3, register_update/3, dialog_update/3, session_update/3]).
 -export([handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
 -include("nksip.hrl").
@@ -494,6 +494,22 @@ register(_ReqId, _From, State) ->
         false -> {method_not_allowed, ?ALLOW}
     end,
     {reply, Reply, State}.
+
+
+%% @doc Called to check which extensions are supported by the application.
+%%
+%% Only called if a request is made to the server with the `Require'
+%% header.
+%%
+%% If this function is not defined, then NkSIP will reply with only
+%% those extensions that it is capable of handling directly.
+%%
+-spec supported(State::term()) ->
+    {reply, Reply, NewState}
+    when Reply :: [binary()], NewState :: term().
+
+supported(State) ->
+    {reply, [], State}.
 
 
 %% @doc Called when a dialog has changed its state.

--- a/nksip/src/nksip_uac_lib.erl
+++ b/nksip/src/nksip_uac_lib.erl
@@ -116,7 +116,7 @@ make(AppId, Method, Uri, Opts, AppOpts) ->
                 false -> []
             end,
             case lists:member(make_supported, FullOpts) of
-                true -> {default_single, <<"Supported">>, ?SUPPORTED};
+                true -> {default_single, <<"Supported">>, nksip_lib:bjoin(?SUPPORTED)};
                 false -> []
             end,
             case lists:member(make_accept, FullOpts) of

--- a/nksip/src/nksip_uas_lib.erl
+++ b/nksip/src/nksip_uas_lib.erl
@@ -153,7 +153,7 @@ response(Req, Code, Headers, Body, Opts) ->
             false -> none
         end,
         case lists:member(make_supported, Opts1) of
-            true -> {default_single, <<"Supported">>, ?SUPPORTED};
+            true -> {default_single, <<"Supported">>, nksip_lib:bjoin(?SUPPORTED)};
             false -> none
         end,
         case lists:member(make_accept, Opts1) of

--- a/nksip/test/sipapp_server.erl
+++ b/nksip/test/sipapp_server.erl
@@ -24,7 +24,7 @@
 -behaviour(nksip_sipapp).
 
 -export([start/2, stop/1, get_domains/1, set_domains/2]).
--export([init/1, get_user_pass/3, authorize/4, route/6, 
+-export([init/1, get_user_pass/3, authorize/4, route/6, supported/1,
         handle_call/3, handle_cast/2, handle_info/2]).
 
 -include_lib("nksip/include/nksip.hrl").
@@ -71,6 +71,11 @@ get_user_pass(<<"client2">>, _, State) ->
     {reply, "4321", State};
 get_user_pass(_User, _Realm, State) -> 
     {reply, false, State}.
+
+
+%% Example extension that this server supports.
+supported(State) ->
+    {reply, [<<"x-supported">>], State}.
 
 
 % Authorization is only used for "auth" suite

--- a/nksip/test/uas_test.erl
+++ b/nksip/test/uas_test.erl
@@ -97,7 +97,7 @@ uas() ->
     {ok, 200, []} = nksip_uac:options(C1, "sip:127.0.0.1", ForceLoopOpts4),
 
     % Test bad extension endpoint and proxy
-    Opts5 = [{headers, [{"Require", "a,b;c,d"}]}, {fields, [all_headers]}],
+    Opts5 = [{headers, [{"Require", "a,b;c,x-supported,d"}]}, {fields, [all_headers]}],
     {ok, 420, [{all_headers, Hds5}]} = nksip_uac:options(C1, "sip:127.0.0.1", Opts5),
     [<<"a,b,d">>] = proplists:get_all_values(<<"Unsupported">>, Hds5),
     
@@ -114,6 +114,11 @@ uas() ->
     nksip_trace:warning("Next warning about a invalid sipreply is expected"),
     {ok, 500,  [{reason, <<"Invalid Response">>}]} = 
         nksip_uac:options(C1, "sip:127.0.0.1", Opts7),
+
+    %% Test supported extension endpoint
+    Opts8 = [{headers, [{"Require", "x-supported"}]}, {fields, [all_headers]}],
+    {ok, 200, _} = nksip_uac:options(C1, "sip:127.0.0.1", Opts8),
+
     ok.
 
 


### PR DESCRIPTION
This callback is utilise when the `Require' header is included in a
request.  By default, only extensions supported by NkSIP itself are
marked as supported.  Otherwise, a SipApp can indicate support by
returning a list of extensions.

Integration with the `make_supported' option is perhaps limited at
this stage.

See RFC 3261, 8.1.1.9 for more information.
