### PR TITLE
Allow to have UAC and UAS for a dialog on the same sipapp

### DIFF
--- a/nksip/src/nksip_call_dialog.erl
+++ b/nksip/src/nksip_call_dialog.erl
@@ -50,7 +50,7 @@ create(Class, Req, Resp) ->
         transport = #transport{proto=Proto},
         from_tag = FromTag
     } = Resp,
-    DialogId = nksip_dialog:id(Resp),
+    DialogId = nksip_dialog:class_id(Class, Resp),
     ?debug(AppId, CallId, "Dialog ~s (~p) created", [DialogId, Class]),
     nksip_counters:async([nksip_dialogs]),
     Now = nksip_lib:timestamp(),

--- a/nksip/src/nksip_call_lib.erl
+++ b/nksip/src/nksip_call_lib.erl
@@ -23,7 +23,7 @@
 -author('Carlos Gonzalez <carlosj.gf@gmail.com>').
 
 -export([update_sipmsg/2, update/2]).
--export([update_auth/3, check_auth/2]).
+-export([update_auth/3, check_auth/3]).
 -export([timeout_timer/3, retrans_timer/3, expire_timer/3, app_timer/3, 
          cancel_timers/2]).
 -export_type([timeout_timer/0, retrans_timer/0, expire_timer/0, timer/0]).
@@ -151,14 +151,14 @@ update_auth(DialogId, SipMsg, #call{auths=Auths}=Call) ->
 
 
 %% @private
--spec check_auth(nksip:request()|nksip:response(), call()) ->
+-spec check_auth(uac|uas,nksip:request()|nksip:response(), call()) ->
     boolean().
 
-check_auth(#sipmsg{to_tag=(<<>>)}, _Call) ->
+check_auth(_, #sipmsg{to_tag=(<<>>)}, _Call) ->
     false;
 
-check_auth(#sipmsg{transport=#transport{}=Transp}=SipMsg, Call) ->
-    case nksip_dialog:id(SipMsg) of
+check_auth(Class, #sipmsg{transport=#transport{}=Transp}=SipMsg, Call) ->
+    case nksip_dialog:class_id(Class, SipMsg) of
         <<>> ->
             false;
         DialogId ->
@@ -178,7 +178,7 @@ check_auth(#sipmsg{transport=#transport{}=Transp}=SipMsg, Call) ->
             end
     end;
 
-check_auth(_, _) ->
+check_auth(_, _, _) ->
     false.
 
 

--- a/nksip/src/nksip_call_uac_dialog.erl
+++ b/nksip/src/nksip_call_uac_dialog.erl
@@ -44,7 +44,7 @@ request(#sipmsg{class={req, 'ACK'}}, _) ->
     error(ack_in_dialog_request);
 
 request(#sipmsg{class={req, Method}}=Req, Call) ->
-    case nksip_dialog:id(Req) of
+    case nksip_dialog:uac_id(Req) of
         <<>> ->
             {ok, Call};
         DialogId ->
@@ -100,7 +100,7 @@ do_request(_Method, _Status, _Req, Dialog, _Call) ->
 
 ack(#sipmsg{class={req, 'ACK'}}=Req, Call) ->
     #sipmsg{cseq=CSeq} = Req,
-    case nksip_dialog:id(Req) of
+    case nksip_dialog:uac_id(Req) of
         <<>> ->
             ?call_notice("Dialog UAC invalid ACK", [], Call),
             Call;
@@ -132,7 +132,7 @@ ack(#sipmsg{class={req, 'ACK'}}=Req, Call) ->
     call().
 
 response(#sipmsg{class={req, Method}}=Req, Resp, #call{dialogs=Dialogs}=Call) ->
-    case nksip_dialog:id(Resp) of
+    case nksip_dialog:uac_id(Resp) of
         <<>> ->
             Call;
         DialogId ->
@@ -259,7 +259,7 @@ make(DialogId, Method, Opts, #call{dialogs=Dialogs}=Call) ->
     {nksip:cseq(), call()}.
 
 new_local_seq(Req, Call) ->
-    case nksip_dialog:id(Req) of
+    case nksip_dialog:uac_id(Req) of
         <<>> ->
             {nksip_config:cseq(), Call};
         DialogId ->

--- a/nksip/src/nksip_call_uac_reply.erl
+++ b/nksip/src/nksip_call_uac_reply.erl
@@ -94,7 +94,7 @@ fun_response(#sipmsg{class={resp, Code}, cseq_method=Method}=Resp, Opts) ->
             {resp, Resp};
         false ->
             Fields0 = case Method of
-                'INVITE' -> [{dialog_id, nksip_dialog:id(Resp)}];
+                'INVITE' -> [{dialog_id, nksip_dialog:uac_id(Resp)}];
                 _ -> []
             end,
             Values = case nksip_lib:get_value(fields, Opts, []) of

--- a/nksip/src/nksip_call_uac_req.erl
+++ b/nksip/src/nksip_call_uac_req.erl
@@ -130,7 +130,7 @@ new_uac(Req, Opts, From, Call) ->
         cancel = undefined,
         iter = 1
     },
-    Msg = {MsgId, Id, nksip_dialog:id(Req)},
+    Msg = {MsgId, Id, nksip_dialog:uac_id(Req)},
     {UAC, Call#call{trans=[UAC|Trans], msgs=[Msg|Msgs], next=Id+1}}.
 
 

--- a/nksip/src/nksip_call_uac_resp.erl
+++ b/nksip/src/nksip_call_uac_resp.erl
@@ -80,7 +80,7 @@ response(Resp, UAC, Call) ->
             {Resp1, _} = nksip_reply:reply(Req, {timeout, <<"Transaction Timeout">>})
     end,
     Call1 = case Code1>=200 andalso Code1<300 of
-        true -> nksip_call_lib:update_auth(nksip_dialog:id(Resp1), Resp1, Call);
+        true -> nksip_call_lib:update_auth(nksip_dialog:uac_id(Resp1), Resp1, Call);
         false -> Call
     end,
     UAC1 = UAC#trans{response=Resp1, code=Code1},
@@ -97,7 +97,7 @@ response(Resp, UAC, Call) ->
         true -> update(UAC1, Call1);
         false -> nksip_call_uac_dialog:response(Req, Resp1, update(UAC1, Call1))
     end,
-    Msg = {MsgId, Id, nksip_dialog:id(Resp)},
+    Msg = {MsgId, Id, nksip_dialog:uac_id(Resp)},
     Call4 = Call3#call{msgs=[Msg|Msgs]},
     response_status(Status, Resp1, UAC1, Call4).
 
@@ -271,7 +271,7 @@ do_received_hangup(Resp, UAC, Call) ->
         true -> UAC;
         false -> UAC#trans{to_tags=ToTags++[ToTag]}
     end,
-    DialogId = nksip_dialog:id(Resp),
+    DialogId = nksip_dialog:uac_id(Resp),
     case Code < 300 of
         true ->
             ?call_info("UAC ~p (~p) sending ACK and BYE to secondary response " 

--- a/nksip/src/nksip_call_uas_dialog.erl
+++ b/nksip/src/nksip_call_uas_dialog.erl
@@ -42,7 +42,7 @@
                   proceeding_uac | proceeding_uas | invalid.
 
 request(Req, Call) ->
-    case nksip_dialog:id(Req) of
+    case nksip_dialog:uas_id(Req) of
         <<>> ->
             {ok, undefined, Call};
         DialogId ->
@@ -133,7 +133,7 @@ do_request(_, _, _, Dialog, _Call) ->
 response(#sipmsg{class={req, Method}}=Req, Resp, Call) ->
     #sipmsg{class={resp, Code}} = Resp,
     #call{dialogs=Dialogs} = Call,
-    case nksip_dialog:id(Resp) of
+    case nksip_dialog:uas_id(Resp) of
         <<>> ->
             Call;
         DialogId ->

--- a/nksip/src/nksip_call_uas_reply.erl
+++ b/nksip/src/nksip_call_uas_reply.erl
@@ -85,7 +85,7 @@ reply({#sipmsg{class={resp, Code}, id=MsgId}=Resp, SendOpts},
     #sipmsg{class={resp, Code1}} = Resp1,
     Call1 = case Req of
         #sipmsg{} when Code1>=200, Code<300 ->
-            nksip_call_lib:update_auth(nksip_dialog:id(Resp1), Req, Call);
+            nksip_call_lib:update_auth(nksip_dialog:uas_id(Resp1), Req, Call);
         _ ->
             Call
     end,
@@ -97,7 +97,7 @@ reply({#sipmsg{class={resp, Code}, id=MsgId}=Resp, SendOpts},
         true -> UAS#trans{response=Resp1, code=Code};
         false -> UAS
     end,
-    Msg = {MsgId, Id, nksip_dialog:id(Resp1)},
+    Msg = {MsgId, Id, nksip_dialog:uas_id(Resp1)},
     Call3 = Call2#call{msgs=[Msg|Msgs]},
     case Stateless of
         true when Method=/='INVITE' ->

--- a/nksip/src/nksip_call_uas_req.erl
+++ b/nksip/src/nksip_call_uas_req.erl
@@ -180,7 +180,7 @@ process_request(Req, TransId, Call) ->
         'ACK' -> UAS;
         _ -> nksip_call_lib:timeout_timer(noinvite, UAS, Call)
     end,
-    Msg = {MsgId, Id, nksip_dialog:id(Req)},
+    Msg = {MsgId, Id, nksip_dialog:uas_id(Req)},
     Call1 = Call#call{trans=[UAS1|Trans], next=Id+1, msgs=[Msg|Msgs]},
     case ToTag=:=(<<>>) andalso lists:keymember(LoopId, #trans.loop_id, Trans) of
         true -> 

--- a/nksip/src/nksip_call_uas_route.erl
+++ b/nksip/src/nksip_call_uas_route.erl
@@ -185,7 +185,7 @@ authorize_launch(UAS, Call) ->
 
 authorize_data(#trans{id=Id,request=Req}, Call) ->
     #call{app_id=AppId, opts=#call_opts{app_module=Module, app_opts=Opts}} = Call,
-    IsDialog = case nksip_call_lib:check_auth(Req, Call) of
+    IsDialog = case nksip_call_lib:check_auth(uas, Req, Call) of
         true -> dialog;
         false -> []
     end,
@@ -222,7 +222,7 @@ authorize_reply(Reply, #trans{status=authorize}=UAS, Call) ->
         _ when Reply=:=ok; Reply=:=true ->
             Call1 = case Req#sipmsg.to_tag of
                 <<>> -> Call;
-                _ -> nksip_call_lib:update_auth(nksip_dialog:id(Req), Req, Call)
+                _ -> nksip_call_lib:update_auth(nksip_dialog:uas_id(Req), Req, Call)
             end,
             route_launch(UAS, Call1);
         false -> 

--- a/nksip/src/nksip_sipmsg.erl
+++ b/nksip/src/nksip_sipmsg.erl
@@ -83,7 +83,7 @@ field(#sipmsg{class=Class, ruri=RUri, transport=T}=S, Field) ->
         content_type -> nksip_unparse:tokens(S#sipmsg.content_type);
         parsed_content_type -> S#sipmsg.content_type;
         body -> S#sipmsg.body;
-        dialog_id -> nksip_dialog:id(S);
+        dialog_id -> exit({nksip_dialog,id,S});
         expire -> S#sipmsg.expire;
         all_headers -> all_headers(S);
         code -> case Class of {resp, Code} -> Code; {req, _} -> 0 end;


### PR DESCRIPTION
If we invite an entity on the same node and the same sipapp as the initiating entity we end up in the same dialog and there is no way to ack the invitation. The easiest way to fix it seems as to have those dialog ids separated.

I'm not sure this is the best solution because the usage of the same dialog id could make it possible to shortcut the request to be processed without actually sending it on the wire.
