### PR TITLE
Skip SCTP test on platforms without support

### DIFF
--- a/test/sctp_test.erl
+++ b/test/sctp_test.erl
@@ -39,6 +39,9 @@ sctp_test_() ->
                 ]
             };
         {error, eprotonosupport} ->
+            ?debugMsg("Skipping SCTP test (no Erlang support)"),
+            [];
+        {error, esocktnosupport} ->
             ?debugMsg("Skipping SCTP test (no OS support)"),
             []
     end.


### PR DESCRIPTION
The test previously would skip it for the case of Erlang not being
built with SCTP support.

This was verified with two different Erlang runtimes on the same
machine reporting different errors.  Only the one built without SCTP
enabled (due to lack of libraries) reported eprotonosupport.
