### PR TITLE
Bugfix: recognize upper/mixedcase transport values

### DIFF
--- a/src/nksip_dns.erl
+++ b/src/nksip_dns.erl
@@ -108,7 +108,8 @@ resolve_uri(#uri{scheme=Scheme, domain=Host, opts=Opts, port=Port}) ->
         Atom when is_atom(Atom) -> 
             Atom;
         Other -> 
-            case catch list_to_existing_atom(nksip_lib:to_list(Other)) of
+            LcTransp = string:to_lower(nksip_lib:to_list(Other)),
+            case catch list_to_existing_atom(LcTransp) of
                 {'EXIT', _} -> nksip_lib:to_binary(Other);
                 Atom -> Atom
             end

--- a/src/nksip_parse.erl
+++ b/src/nksip_parse.erl
@@ -140,7 +140,8 @@ transport(#uri{scheme=Scheme, domain=Host, port=Port, opts=Opts}) ->
         Atom when is_atom(Atom) -> 
             Atom;
         Other ->
-            case catch list_to_existing_atom(nksip_lib:to_list(Other)) of
+            LcTransp = string:to_lower(nksip_lib:to_list(Other)),
+            case catch list_to_existing_atom(LcTransp) of
                 {'EXIT', _} -> nksip_lib:to_binary(Other);
                 Atom -> Atom
             end


### PR DESCRIPTION
Values for SIP transport were not recognized when they were not all
lowercase, e.g. if the peer would send "transport=TLS" it would not
work.
