### PR TITLE
Remove dependency on ssl_internal.hrl

### DIFF
--- a/include/nksip.hrl
+++ b/include/nksip.hrl
@@ -76,13 +76,14 @@
          "~p (~s) "++Txt, [AppId, CallId|Opts])).
 
 
--include_lib("ssl/src/ssl_internal.hrl"). 
 -include_lib("kernel/include/inet_sctp.hrl").
 
 
 %% ===================================================================
 %% Types
 %% ===================================================================
+
+-type from() :: term().
 
 -type gen_server_time() :: 
         non_neg_integer() | hibernate.

--- a/src/nksip_transport_tcp.erl
+++ b/src/nksip_transport_tcp.erl
@@ -158,7 +158,7 @@ start_link(AppId, Transport, Socket) ->
 -record(state, {
     app_id :: nksip:app_id(),
     transport :: nksip_transport:transport(),
-    socket :: port() | #sslsocket{},
+    socket :: port() | ssl:sslsocket(),
     timeout :: non_neg_integer(),
     buffer = <<>> :: binary()
 }).


### PR DESCRIPTION
This include has changed as of R16B03 and depending on internal
structures of external applications leads to problems.  In this case,
nksip will fail to build on R16B03.

The type `from/0` is duplicated from ssl_internal.h.  I suspect this
should be a more specific type, but unsure what that should be for now.
