### PR TITLE
Remove reg-id checking in the GRUU plugin

### DIFF
--- a/plugins/src/nksip_gruu_lib.erl
+++ b/plugins/src/nksip_gruu_lib.erl
@@ -160,7 +160,7 @@ update_regcontact(RegContact, Base, Req, Opts) ->
     RegId = nksip_lib:get_binary(<<"reg-id">>, ExtOpts),
     Expires = nksip_lib:get_integer(<<"expires">>, ExtOpts),
     case 
-        InstId /= <<>> andalso RegId == <<>> andalso 
+        InstId /= <<>> andalso 
         Expires>0 andalso lists:member({gruu, true}, Opts)
     of
         true ->


### PR DESCRIPTION
I am working a bit with jssip and in my troubleshooting discovered that GRUU was not working as expected.   Jssip is sending a reg-id (for outbound support) and the existence of this header caused GRUU not to generate GRUU ids.  I did some searching and it appears reg-id is completely optional in terms of GRUU and so I removed the check completely.    Let me know if I missed something here.  

Thanks!
