### PR TITLE
Workaround for malicious/broken SIP-clients

### DIFF
--- a/src/nksip_parse_sipmsg.erl
+++ b/src/nksip_parse_sipmsg.erl
@@ -125,6 +125,9 @@ first(Bin) ->
         {Uri, <<"SIP/2.0\r\n", Rest2/binary>>} ->
             RUri = <<$<, (list_to_binary(Uri))/binary, $>>>,
             {req, nksip_parse:method(Method), RUri, Rest2};
+        {Uri, <<"SIP/2.0\n", Rest3/binary>>} ->
+            RUri = <<$<, (list_to_binary(Uri))/binary, $>>>,
+            {req, nksip_parse:method(Method), RUri, Rest3};
         _ ->
             throw({line, ?LINE})
     end.
@@ -136,6 +139,8 @@ headers(<<>>, _Acc) ->
 
 headers(<<"\r\n", Body/binary>>, Acc) ->
     {lists:reverse(Acc), Body};
+headers(<<"\n", Body/binary>>, Acc) ->
+    headers(<<$\r, $\n, Body/binary>>, Acc);
 
 headers(Bin, Acc) ->
     {Name, Value, Rest} = name(Bin, []),
@@ -150,6 +155,7 @@ headers(Bin, Acc) ->
 name(<<$\s, Rest/binary>>, Acc) -> colon(remove_ws(Rest), lists:reverse(Acc));
 name(<<$\t, Rest/binary>>, Acc) -> colon(remove_ws(Rest), lists:reverse(Acc));
 name(<<$\r, $\n, _/binary>>, _Acc) -> throw({line, ?LINE});
+name(<<$\n, Rest/binary>>, Acc) -> name(<<$\r, $\n, Rest/binary>>, Acc);
 name(<<$:, Rest/binary>>, Acc) -> value(remove_ws(Rest), lists:reverse(Acc), []);
 name(<<Ch, Rest/binary>>, Acc) when Ch>=$A, Ch=<$Z -> name(Rest, [Ch+32|Acc]);
 name(<<Ch, Rest/binary>>, Acc) -> name(Rest, [Ch|Acc]);
@@ -165,6 +171,7 @@ colon(_, _N) -> throw({line, ?LINE}).
 value(<<$\r, $\n, $\s, Rest/binary>>, N, Acc) -> value(remove_ws(Rest), N, [$\s|Acc]);
 value(<<$\r, $\n, $\t, Rest/binary>>, N, Acc) -> value(remove_ws(Rest), N, [$\s|Acc]);
 value(<<$\r, $\n, Rest/binary>>, N, Acc) -> {N, lists:reverse(Acc), Rest};
+value(<<$\n, Rest/binary>>, N, Acc) -> value(<<$\r, $\n, Rest/binary>>, N, Acc);
 value(<<Ch, Rest/binary>>, N, Acc) -> value(Rest, N, [Ch|Acc]);
 value(<<>>, _N, _Acc) -> throw({line, ?LINE}).
 
@@ -178,6 +185,7 @@ until_sp(<<Ch, Rest/binary>>, Acc) -> until_sp(Rest, [Ch|Acc]).
 
 %% @private
 until_rn(<<$\r, $\n, Rest/binary>>, Acc) -> {lists:reverse(Acc), Rest};
+until_rn(<<$\n, Rest/binary>>, Acc) -> until_rn(<<$\r, $\n, Rest/binary>>, Acc);
 until_rn(<<>>, _Acc) -> throw({line, ?LINE});
 until_rn(<<Ch, Rest/binary>>, Acc) -> until_rn(Rest, [Ch|Acc]).
 


### PR DESCRIPTION
Hello All!

Some nasty SIP-clients sends only \n instead of \r\n (malicious SIP scanners). We shouldn't crash
on these packets. 

Actually I'm not sure about how we should handle this. RFC 3261 states clearly that the only allowed line terminator is CRLF, however previous RFC 2543 does allows line endings with CR, LF, and CRLF. Also some people advise allowing CRLF, CR, and LF as a line delimiters when parsing incoming SIP packets (see http://www.networksorcery.com/enp/protocol/sip.htm).

What other thinks about this? Is it worth fixing at all?
