### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Travis CI still fails sometimes due to timers
 
 ## Introduction
 
-NkSIP is an Erlang SIP framework or _application server_, which greatly facilitates the development of robust and scalable server-side SIP applications like [proxy](http://en.wikipedia.org/wiki/Session_Initiation_Protocol#Proxy_server), [registrar](http://en.wikipedia.org/wiki/Session_Initiation_Protocol#Registrar), [redirect](http://en.wikipedia.org/wiki/Session_Initiation_Protocol#Redirect_server) or outbound servers, [B2BUAs](http://en.wikipedia.org/wiki/Back-to-back_user_agent), [SBCs](https://en.wikipedia.org/wiki/Session_border_controller) or load generators. NkSIP takes care of much of the SIP complexity, while allowing full access to requests and responses. 
+NkSIP is an Erlang SIP framework or _application server_, which greatly facilitates the development of robust and scalable server-side SIP applications like [proxy](http://en.wikipedia.org/wiki/Session_Initiation_Protocol#Proxy_server), [registrar](http://en.wikipedia.org/wiki/Session_Initiation_Protocol#Registrar), [redirect](http://en.wikipedia.org/wiki/Session_Initiation_Protocol#Redirect_server) or outbound servers, [B2BUAs](https://en.wikipedia.org/wiki/Back-to-back_user_agent), [SBCs](https://en.wikipedia.org/wiki/Session_border_controller) or load generators. NkSIP takes care of much of the SIP complexity, while allowing full access to requests and responses. 
 
 **IMPORTANT** - This version has important, incompatible changes, see the [CHANGELOG](doc/changelog.md) - **IMPORTANT**
 
@@ -64,7 +64,7 @@ NkSIP scales automatically using all of the available cores on the machine. Usin
 NkSIP has been tested on OSX and Linux, using Erlang 17
 
 ```
-> git clone https://github.com/kalta/nksip
+> git clone https://github.com/NetComposer/nksip
 > cd nksip
 > make
 > make tests


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/kalta/nksip | https://github.com/NetComposer/nksip 


### HTTPS Corrected URLs 
Was | Now 
--- | --- 
http://en.wikipedia.org/wiki/Back-to-back_user_agent | https://en.wikipedia.org/wiki/Back-to-back_user_agent 
