### PR TITLE
Sip fixes

### DIFF
--- a/src/nksip_call_dialog.erl
+++ b/src/nksip_call_dialog.erl
@@ -114,6 +114,9 @@ update(Type, Dialog, #call{srv_id=SrvId}=Call) ->
 -spec do_update(term(), nksip:dialog(), nksip_call:call()) ->
     nksip_call:call().
 
+do_update({invite, {stop, _ } }, #dialog{id=DialogId, invite=undefined}, Call) ->
+    ?call_debug("Dialog stop of already stoped dialog ~s", [DialogId]),
+    Call;
 do_update({invite, {stop, Reason}}, #dialog{invite=Invite}=Dialog, Call) ->
     #invite{
         media_started = Media,

--- a/src/nksip_call_dialog.erl
+++ b/src/nksip_call_dialog.erl
@@ -576,7 +576,12 @@ do_timer({event, Tag}, Dialog, Call) ->
     nksip:dialog() | not_found.
 
 find(Id, #call{dialogs=Dialogs}) ->
-    do_find(Id, Dialogs).
+    case do_find(Id, Dialogs) of
+        not_found ->
+            do_find2(Id, Dialogs);
+        Found ->
+            Found
+    end.
 
 
 %% @private
@@ -587,6 +592,13 @@ do_find(_, []) -> not_found;
 do_find(Id, [#dialog{id=Id}=Dialog|_]) -> Dialog;
 do_find(Id, [_|Rest]) -> do_find(Id, Rest).
 
+%% @private
+-spec do_find2(nksip_dialog_lib:id(), [nksip:dialog()]) ->
+    nksip:dialog() | not_found.
+
+do_find2(_, []) -> not_found;
+do_find2(Id, [#dialog{invite=#invite{request=#sipmsg{dialog_id=Id}}}=Dialog|_]) -> Dialog;
+do_find2(Id, [_|Rest]) -> do_find(Id, Rest).
 
 %% @private Updates a dialog into the call
 -spec store(nksip:dialog(), nksip_call:call()) ->

--- a/src/nksip_call_event.erl
+++ b/src/nksip_call_event.erl
@@ -319,6 +319,10 @@ update({notify, Req}, Subs, Dialog, Call) ->
     end,
     update(Status, Subs1, Dialog, Call);
 
+update({Status, undefined}, #subscription{ id = Id }, Dialog, _Call)  ->
+    ?call_debug("Avoid to store subscption ~s: expires is undefined (status: ~p)", [ Id, Status ]),
+    Dialog;
+
 update({Status, Expires}, Subs, Dialog, Call) 
         when Status==active; Status==pending ->
     #subscription{

--- a/src/nksip_call_uac_transp.erl
+++ b/src/nksip_call_uac_transp.erl
@@ -53,7 +53,8 @@ send_request(Req, Opts) ->
             DestUri = RUri1 = RUri,
             Routes1 = [];
         [#uri{opts=RouteOpts}=TopRoute|RestRoutes] ->
-            case lists:member(<<"lr">>, RouteOpts) of
+            ?call_debug("UAC send route opts: ~p", [RouteOpts]),
+            case lists:member(<<"lr">>, RouteOpts) orelse proplists:is_defined(<<"lr">>, RouteOpts) of
                 true ->     
                     DestUri = TopRoute#uri{
                         scheme = case RUri#uri.scheme of

--- a/src/nksip_call_uas_make.erl
+++ b/src/nksip_call_uas_make.erl
@@ -78,7 +78,11 @@ make(Req, Code, Opts) ->
         cseq = {CSeqNum, Method},
         routes = [],
         contacts = [],
-        headers = [],
+        headers = case nksip_sipmsg:header(<<"record-route">>, Req) of
+                      [] ->
+                          [];
+                      RR -> [{ <<"record-route">>, RR }]
+                  end,
         content_type = undefined,
         supported = [],
         require = [],

--- a/src/nksip_call_uas_make.erl
+++ b/src/nksip_call_uas_make.erl
@@ -56,8 +56,9 @@ make(Req, Code, Opts) ->
     case Code of
         100 -> 
             Vias1 = [LastVia],
-            ExtOpts1 = lists:keydelete(<<"tag">>, 1, ExtOpts),
-            {To1, ToTag1} = {To#uri{ext_opts=ExtOpts1}, <<>>};
+            %% ExtOpts1 = lists:keydelete(<<"tag">>, 1, ExtOpts),
+            %% {To1, ToTag1} = {To#uri{ext_opts=ExtOpts1}, ToTag};
+            {To1, ToTag1} = {To, ToTag};
         _ -> 
             Vias1 = Vias,
             {To1, ToTag1} = case ToTag of

--- a/src/nksip_sipmsg.erl
+++ b/src/nksip_sipmsg.erl
@@ -37,7 +37,7 @@
 
 -type field() ::  
     handle | internal_id | srv_id | srv_name | dialog_handle | subscription_handle |
-    transp | local | remote | method | ruri | scheme | user | domain | aor |
+    nkport | transp | local | remote | method | ruri | scheme | user | domain | aor |
     code | reason_phrase | content_type | body | call_id | vias | 
     from | from_tag | from_scheme | from_user | from_domain | 
     to | to_tag | to_scheme | to_user | to_domain | 
@@ -71,6 +71,7 @@ meta(Name, #sipmsg{class=Class, ruri=RUri, from=From, to=To}=S) ->
         srv_name -> apply(S#sipmsg.srv_id, name, []);
         dialog_handle -> nksip_dialog_lib:get_handle(S);
         subscription_handle -> nksip_subscription_lib:get_handle(S);
+        nkport -> S#sipmsg.nkport;
         transp -> 
             case S#sipmsg.nkport of
                 #nkport{transp=P} -> P; 

--- a/src/plugins/nksip_trace_callbacks.erl
+++ b/src/plugins/nksip_trace_callbacks.erl
@@ -74,6 +74,10 @@ plugin_stop(Config, #{id:=Id, name:=Name}) ->
 -spec nks_sip_connection_sent(nksip:request()|nksip:response(), binary()) ->
     continue.
 
+nks_sip_connection_sent(SipMsg, { text, Packet }) ->
+    nks_sip_connection_sent(SipMsg, Packet);
+nks_sip_connection_sent(SipMsg, { binary, Packet }) ->
+    nks_sip_connection_sent(SipMsg, Packet);
 nks_sip_connection_sent(SipMsg, Packet) ->
     #sipmsg{srv_id=SrvId, call_id=CallId, nkport=NkPort} = SipMsg,
     nksip_trace:sipmsg(SrvId, CallId, <<"TO">>, NkPort, Packet),

--- a/test/basic_test.erl
+++ b/test/basic_test.erl
@@ -115,7 +115,7 @@ running() ->
     
 
 transport() ->
-    Body = base64:encode(crypto:rand_bytes(100)),
+    Body = base64:encode(crypto:strong_rand_bytes(100)),
     Opts1 = [
         {add, "x-nksip", "test1"}, 
         {add, "x-nk-op", "reply-request"}, 


### PR DESCRIPTION
Several fixes of the SIP protocol:
* Copy record-route in response
* Timer E for UDP transport for non-INVITE transactions
* Accept kamailio lr=on loose route option (enable_full_lr of rr module)
* Phone-specific issues:
** Resync of Cisco phone
** Polycom hold (it doesn't accept 100 trying without to-tag in Re-INVITE)
* Find dialog by initial ID (before get to-tag) is supported