### PR TITLE
ADD Header based trace

### DIFF
--- a/src/plugins/nksip_trace.erl
+++ b/src/plugins/nksip_trace.erl
@@ -193,7 +193,7 @@ sipmsg(SrvId, _CallId, Header, Transport, Binary) ->
                 _Match ->
                     SrvName = SrvId:name(),
                     Msg = print_packet(SrvName, Header, Transport, Binary),
-                    write(SrvId, File, Msg);
+                    write(SrvId, File, Msg)
             end;
         {File, IpList} ->
             #nkport{local_ip=Ip1, remote_ip=Ip2} = Transport,
@@ -410,7 +410,7 @@ checkTraceOptions(Options) ->
         Opts when is_list(Options)->
             is_ipaddList(Opts);
         _oth ->
-            {error, invalid_input_options};
+            {error, invalid_input_options}
     end.
 
 %% @private

--- a/src/plugins/nksip_trace.erl
+++ b/src/plugins/nksip_trace.erl
@@ -30,7 +30,7 @@
 
 -export([get_all/0, start/0, start/1, start/2, start/3, stop/0, stop/1]).
 -export([print/1, print/2, sipmsg/5]).
--export([get_config/2, open_file/2, close_file/1,is_BinList/1]).
+-export([get_config/2, open_file/2, close_file/1]).
 
 -include_lib("nkpacket/include/nkpacket.hrl").
 -include("../include/nksip.hrl").
@@ -424,7 +424,7 @@ is_binList([H|T])->
         false ->
             {error, not_binary_list};
         true ->
-            is_BinList(T)
+            is_binList(T)
     end.
 
 

--- a/src/plugins/nksip_trace.erl
+++ b/src/plugins/nksip_trace.erl
@@ -85,11 +85,7 @@ start(Srv) ->
 start(all, File) ->
     lists:map(
         fun({SrvId, SrvName, _Pid}) -> {SrvName, start(SrvId,File)} end,
-        nkservice:get_all(nksip)).
-
-%% @doc Equivalent to `start(Srv, File, all)'.
--spec start(nksip:srv_id()|nkservice:name(), file()) -> 
-    ok | {error, term()}.
+        nkservice:get_all(nksip));
 
 start(Srv, File) -> 
     start(Srv, File, all).
@@ -101,12 +97,7 @@ start(Srv, File) ->
 start(all, File,IpList) ->
     lists:map(
         fun({SrvId, SrvName, _Pid}) -> {SrvName, start(SrvId,File,IpList)} end,
-        nkservice:get_all(nksip)).
-
-
-%% @doc Configures a Service to start tracing SIP messages.
--spec start(nksip:srv_id()|nksip:srv_id(), file(), ip_list()|sip_content()) ->
-    ok | {error, term()}.
+        nkservice:get_all(nksip));
 
 start(Srv, File, IpList) ->
     case checkTraceOptions(IpList) of

--- a/src/plugins/nksip_trace.erl
+++ b/src/plugins/nksip_trace.erl
@@ -30,7 +30,7 @@
 
 -export([get_all/0, start/0, start/1, start/2, start/3, stop/0, stop/1]).
 -export([print/1, print/2, sipmsg/5]).
--export([get_config/2, open_file/2, close_file/1]).
+-export([get_config/2, open_file/2, close_file/1,is_BinList/1]).
 
 -include_lib("nkpacket/include/nkpacket.hrl").
 -include("../include/nksip.hrl").
@@ -418,6 +418,7 @@ is_ipaddList([H|T])->
 %% @private
 is_binList([]) ->
     ok;
+
 is_binList([H|T])->
     case is_binary(H) of
         false ->


### PR DESCRIPTION
Added Header string based trace. In the current trace plugin there is option to trace based on IP or for a server.
In practical cases, when the server in production mode, we may require trace for a particular from URI or to URI or any other header value to debug an issue.
The provision to trace with any string values mach in SIP message is added in this branch.