### PR TITLE
Fix crash when getting re-invite while in bye state

### DIFF
--- a/src/nksip.erl
+++ b/src/nksip.erl
@@ -59,9 +59,9 @@
 -type config() ::
     #{
         plugins => [atom()],
-        sip_listen => binary(),
+        sip_listen => binary()|string(),
         sip_allow => [binary()|string()],
-        sip_supported => binary(),
+        sip_supported => [binary()|string()],
         sip_timer_t1 => integer(),
         sip_timer_t2 => integer(),
         sip_timer_t4 => integer(),

--- a/src/nksip.erl
+++ b/src/nksip.erl
@@ -60,7 +60,7 @@
     #{
         plugins => [atom()],
         sip_listen => binary(),
-        sip_allow => binary(),
+        sip_allow => [binary()|string()],
         sip_supported => binary(),
         sip_timer_t1 => integer(),
         sip_timer_t2 => integer(),

--- a/src/nksip_call_uas_dialog.erl
+++ b/src/nksip_call_uas_dialog.erl
@@ -110,7 +110,9 @@ do_request('INVITE', _Req, #dialog{invite=#invite{status=Status}}, _Call) ->
         proceeding_uas ->
             {error, retry()};
         accepted_uas ->
-            {error, retry()}
+            {error, retry()};
+        bye ->
+            {error, no_transaction}
     end;
 
 do_request('BYE', _Req, #dialog{invite=#invite{}=Invite}=Dialog, Call) ->


### PR DESCRIPTION
In case of retransmit etc, which can legitimately happen, this tears down the call process completely replying 500 instead of a more expected 481.