### PR TITLE
nksip_router:resend_worklist function might cause calling process to hang for gen_server:call timeout

### DIFF
--- a/src/nksip_call_srv.erl
+++ b/src/nksip_call_srv.erl
@@ -100,10 +100,10 @@ get_all() ->
 
 
 %% @private Validate if given Pid is alive process
--spec validate_process(pid()) ->
+-spec validate_process(list()) ->
     pid() | undefined.
 
-validate_process(Pid) when is_pid(Pid) ->
+validate_process([{_, Pid}]) when is_pid(Pid) ->
   case is_process_alive(Pid) of
     true ->
       Pid;

--- a/src/nksip_uac.erl
+++ b/src/nksip_uac.erl
@@ -94,6 +94,7 @@
     % Publish
     {sip_if_match, binary()} |
 
+    async |
     no_dialog |
     stateless_via |
 

--- a/src/nksip_uac.erl
+++ b/src/nksip_uac.erl
@@ -22,7 +22,7 @@
 %%
 %% In case of using a SIP URI as destination, is is possible to include
 %% custom headers: `"<sip:host;method=REGISTER?contact=*&expires=10>"'
-%% 
+%%
 -module(nksip_uac).
 -author('Carlos Gonzalez <carlosj.gf@gmail.com>').
 
@@ -44,9 +44,9 @@
 %% ===================================================================
 
 
--type uac_result() ::  
+-type uac_result() ::
     {ok, nksip:sip_code(), nksip:resp_options()} | {async, nksip:handle()} | {error, term()}.
-    
+
 -type uac_ack_result() ::
     ok | async | {error, term()}.
 
@@ -66,6 +66,7 @@
     allow |
     accept |
     allow_event |
+    contact |
 
     % Special parameters
     to_as_from |
@@ -403,9 +404,9 @@ refresh(Handle, Opts) ->
 
 %% @doc Sends a <i>STUN</i> binding request.
 %%
-%% Use this function to send a STUN binding request to a remote STUN or 
+%% Use this function to send a STUN binding request to a remote STUN or
 %% STUN-enabled SIP server, in order to get our external ip and port.
-%% If the remote server is a standard STUN server, use port 3478 
+%% If the remote server is a standard STUN server, use port 3478
 %% (i.e. `sip:stunserver.org:3478'). If it is a STUN server embedded into a SIP UDP
 %% server, use a standard SIP uri.
 %%
@@ -485,7 +486,7 @@ send(SrvId, Method, Uri, Opts) ->
 send_dialog(Method, Handle, Opts) ->
     case nksip_dialog:get_handle(Handle) of
         {ok, DlgHandle} ->
-            Opts1 = case Handle of 
+            Opts1 = case Handle of
                 <<$U, $_, _/binary>>=SubsHandle ->
                     [{subscription, SubsHandle}|Opts];
                 _ ->
@@ -505,7 +506,7 @@ send_dialog(Method, Handle, Opts) ->
 %% @private
 -spec send_cancel(nksip:handle(), [req_option()]) ->
     uac_ack_result().
-    
+
 send_cancel(Handle, Opts) ->
     case nksip_sipmsg:parse_handle(Handle) of
         {req, SrvId, ReqId, CallId} ->


### PR DESCRIPTION
The scenario:

1. There is sip dialog opened
2. SIP BYE arrives and sip_bye callback is being called
3. Client notified by sip_bye callback calls nksip_request:reply
4. nksip_router sends work to its nksip_call_srv worker process
5. Meanwhile dialog is closed and nksip_call_srv process stops without
   notifying nksip_router that it started processing the next work
6. nksip_router receives 'DOWN' message from stopped process and
   calls nksip_router:resend_worklist
7. nksip_call_srv:find_call is executed, but it doesn't check if found
   Pid is of alive process, it just checks that it is the valid pid
8. nksip_router sends work as gen_server:cast to not exisnting
   process, so it will never call gen_server:reply to calling process,
   causing calling process to wait till timeout.

The solution:
make nksip_call_srv:find_call function to check if process is alive