### PR TITLE
Dont resend BYE in INVITE bye state.

### DIFF
--- a/src/nksip_call_dialog.erl
+++ b/src/nksip_call_dialog.erl
@@ -571,7 +571,7 @@ do_timer(invite_refresh, #dialog{invite=Invite}=Dialog, Call) ->
 
 do_timer(invite_timeout, #dialog{id=DialogId, invite=Invite}=Dialog, Call) ->
     case Invite of
-        #invite{class=Class} ->
+        #invite{class=Class, status=Status} when Status /= bye ->
             ?CALL_LOG(notice, "Dialog ~s (~p) timeout timer fired", [DialogId, Invite#invite.status], Call),
             case Class of
                 proxy ->
@@ -590,6 +590,9 @@ do_timer(invite_timeout, #dialog{id=DialogId, invite=Invite}=Dialog, Call) ->
                             update({invite, {stop, timeout}}, Dialog, Call)
                     end
             end;
+        #invite{class=Class, status=bye} ->
+            ?CALL_LOG(warning, "Timeout in bye state - end the dialog ~p", [DialogId], Call),
+            update({invite, {stop, timeout}}, Dialog, Call);
         _ ->
             ?CALL_LOG(notice, "Dialog ~s unknown INVITE timeout timer", [DialogId], Call),
             Call


### PR DESCRIPTION
When UAC sends the SIP:BYE and UAS doesn't respond with SIP:OK the NkSIP shall resend SIP:BYE on timeout. Instead it shall just close the dialog.