### PR TITLE
Ignore invite timeout in proceeding states

### DIFF
--- a/src/nksip_call_dialog.erl
+++ b/src/nksip_call_dialog.erl
@@ -571,7 +571,7 @@ do_timer(invite_refresh, #dialog{invite=Invite}=Dialog, Call) ->
 
 do_timer(invite_timeout, #dialog{id=DialogId, invite=Invite}=Dialog, Call) ->
     case Invite of
-        #invite{class=Class} ->
+        #invite{class=Class, status=Status} when Status /= bye ->
             ?CALL_LOG(notice, "Dialog ~s (~p) timeout timer fired", [DialogId, Invite#invite.status], Call),
             case Class of
                 proxy ->
@@ -590,6 +590,9 @@ do_timer(invite_timeout, #dialog{id=DialogId, invite=Invite}=Dialog, Call) ->
                             update({invite, {stop, timeout}}, Dialog, Call)
                     end
             end;
+        #invite{class=Class, status=bye} ->
+            ?CALL_LOG(warning, "Timeout in bye state - end the dialog ~p", [DialogId], Call),
+            update({invite, {stop, timeout}}, Dialog, Call);
         _ ->
             ?CALL_LOG(notice, "Dialog ~s unknown INVITE timeout timer", [DialogId], Call),
             Call

--- a/src/nksip_call_dialog.erl
+++ b/src/nksip_call_dialog.erl
@@ -593,7 +593,7 @@ do_timer(invite_timeout, #dialog{id=DialogId, invite=Invite}=Dialog, Call) ->
         #invite{status=bye} ->
             ?CALL_LOG(warning, "Timeout in bye state - end the dialog ~p", [DialogId], Call),
             update({invite, {stop, timeout}}, Dialog, Call);
-        #invite{status=proceeding_uac} ->
+        #invite{status=Status} when Status == proceeding_uac; Status == proceeding_uas ->
             ?CALL_LOG(notice, "Dialog ~s timeout in proceeding state - ignored", [DialogId], Call),
             Call;
         _ ->

--- a/src/nksip_call_dialog.erl
+++ b/src/nksip_call_dialog.erl
@@ -571,7 +571,7 @@ do_timer(invite_refresh, #dialog{invite=Invite}=Dialog, Call) ->
 
 do_timer(invite_timeout, #dialog{id=DialogId, invite=Invite}=Dialog, Call) ->
     case Invite of
-        #invite{class=Class, status=Status} when Status /= bye ->
+        #invite{class=Class, status=Status} when Status /= bye, Status /= proceeding_uac, Status /= proceeding_uas ->
             ?CALL_LOG(notice, "Dialog ~s (~p) timeout timer fired", [DialogId, Invite#invite.status], Call),
             case Class of
                 proxy ->
@@ -590,9 +590,12 @@ do_timer(invite_timeout, #dialog{id=DialogId, invite=Invite}=Dialog, Call) ->
                             update({invite, {stop, timeout}}, Dialog, Call)
                     end
             end;
-        #invite{class=Class, status=bye} ->
+        #invite{status=bye} ->
             ?CALL_LOG(warning, "Timeout in bye state - end the dialog ~p", [DialogId], Call),
             update({invite, {stop, timeout}}, Dialog, Call);
+        #invite{status=proceeding_uac} ->
+            ?CALL_LOG(notice, "Dialog ~s timeout in proceeding state - ignored", [DialogId], Call),
+            Call;
         _ ->
             ?CALL_LOG(notice, "Dialog ~s unknown INVITE timeout timer", [DialogId], Call),
             Call


### PR DESCRIPTION
Currently the invite timeout of 32 seconds is applied to all states of the dialog. The RFC mentions about this timer only when SIP:INVITE is not responded with any reply. Upon provisioning replies (SIP:1xx) the timer shall be ignored.